### PR TITLE
Add capture window feature and other changes.

### DIFF
--- a/Example/Screenshots/Base.lproj/Main.storyboard
+++ b/Example/Screenshots/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -742,10 +742,22 @@
                                     <action selector="soundEnabledPressed:" target="XfG-lQ-9wD" id="Ldp-sj-Gyw"/>
                                 </connections>
                             </button>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bHh-9L-2hp">
+                                <rect key="frame" x="7" y="3" width="132" height="32"/>
+                                <buttonCell key="cell" type="push" title="Capture window" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="vue-ET-laP">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="captureWindowPressed:" target="XfG-lQ-9wD" id="7DB-h9-F5e"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="bHh-9L-2hp" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="14" id="1BH-iQ-aD9"/>
                             <constraint firstAttribute="trailing" secondItem="Srk-J0-g5K" secondAttribute="trailing" id="1g0-1t-DfI"/>
                             <constraint firstItem="FoD-a0-Pkp" firstAttribute="top" secondItem="ZfK-AB-imd" secondAttribute="bottom" constant="10" id="2ju-Nn-dNN"/>
+                            <constraint firstItem="bHh-9L-2hp" firstAttribute="centerY" secondItem="FoD-a0-Pkp" secondAttribute="centerY" id="3be-T1-lwr"/>
                             <constraint firstItem="ZfK-AB-imd" firstAttribute="top" secondItem="Srk-J0-g5K" secondAttribute="bottom" constant="10" id="9Ek-F5-oya"/>
                             <constraint firstAttribute="trailing" secondItem="toi-UU-OIU" secondAttribute="trailing" constant="9" id="BRF-vW-Su6"/>
                             <constraint firstItem="ZfK-AB-imd" firstAttribute="centerX" secondItem="FoD-a0-Pkp" secondAttribute="centerX" id="F0G-wy-MoS"/>

--- a/Example/Screenshots/ViewController.swift
+++ b/Example/Screenshots/ViewController.swift
@@ -44,6 +44,14 @@ class ViewController: NSViewController {
   @IBAction func soundEnabledPressed(_ sender: Any) {
     cliScreenshots.soundEnabled = soundEnabledField.state == .on
   }
+  
+  @IBAction func captureWindowPressed(_ sender: Any) {
+    cliScreenshots.captureWindow { [weak self] (url) in
+      guard let self = self, let url = url else { return }
+      self.imageView.image = NSImage(contentsOf: url)
+    }
+  }
+  
 }
 
 extension ViewController: ScreenshotWatcherDelegate {


### PR DESCRIPTION
@memstel 
This PR adds support for capturing macOS windows with the help of `screencapture` tool.
https://user-images.githubusercontent.com/15073398/105529538-315c3e00-5cef-11eb-8a3d-781705c77947.mov

The other changes are

1. Use cachesDirectory to store temporary files instead of applicationSupportDirectory
2. Only allow mouse selection mode for regular screenshots