### PR TITLE
Add support of rectangle selection that should be captured

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Screenshots (0.3.3)
+  - Screenshots (0.4.0)
 
 DEPENDENCIES:
   - Screenshots (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Screenshots: 3c7599d6fa6408d4747b20815fadb631cd082219
+  Screenshots: 42c9662e99add5df6c5fdf52c3d83d2e3e6d131a
 
 PODFILE CHECKSUM: 0324bfdd26f6a2c4a3bf31bc65444e20758e029d
 

--- a/Example/Pods/Local Podspecs/Screenshots.podspec.json
+++ b/Example/Pods/Local Podspecs/Screenshots.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Screenshots",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "summary": "Create screenshots on macOS via the screencapture CLI.",
   "description": "This lib allows you to create screenshots including screen coordinates via the screencapture CLI.\nIt also supports watching Desktop for any system screenshots.",
   "homepage": "https://github.com/blackbeltlabs/Screenshots",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/blackbeltlabs/Screenshots.git",
-    "tag": "0.3.3"
+    "tag": "0.4.0"
   },
   "social_media_url": "https://twitter.com/mirkokiefer",
   "platforms": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Screenshots (0.3.3)
+  - Screenshots (0.4.0)
 
 DEPENDENCIES:
   - Screenshots (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Screenshots: 3c7599d6fa6408d4747b20815fadb631cd082219
+  Screenshots: 42c9662e99add5df6c5fdf52c3d83d2e3e6d131a
 
 PODFILE CHECKSUM: 0324bfdd26f6a2c4a3bf31bc65444e20758e029d
 

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -9,28 +9,29 @@
 /* Begin PBXBuildFile section */
 		0DD2BFA2B7C20804A491FFEB1176480D /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1430F003D39D9906881A6AC724B7931 /* Cocoa.framework */; };
 		133C1F800F6741066B3C5504DEAA2DBC /* Pods-Screenshots_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BF3452684FFAB3642CB7A8A9CB11EB0F /* Pods-Screenshots_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		15060517AB5F962725C9FF4BFC75136D /* Screenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCA8C4EAE9B1438F6BFC6853B053BC5 /* Screenshot.swift */; };
 		286A8ABDD90A97D0A911FBB7903914CD /* Pods-Screenshots_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A3FEFCA7C98EECC85FB4254CD86EA3F /* Pods-Screenshots_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6D0F162DC3B8519A6DCBA13E9E512587 /* Screenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC6FD4CBEFBE3FB09422D43E67A6C4B /* Screenshot.swift */; };
+		56C8C841CA3365075E7A38A3BA842A59 /* ScreenshotCLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E480D119F53E9FA0A3952A8B956037B /* ScreenshotCLI.swift */; };
+		6F7C812FBE20F8DCE4A682C6F7C217F8 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB405C3718E68F723F2E3CC29ADDB94 /* StringExtension.swift */; };
 		7AA9E18C2D6D50639060DF43138C6F27 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1430F003D39D9906881A6AC724B7931 /* Cocoa.framework */; };
-		7B8116297ED33AA14C831B1460431BA4 /* ScreenshotCLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A180AA9828AE797B91A649108C013E35 /* ScreenshotCLI.swift */; };
-		7F9295BA12BD92A07A1EAFFD3C4A6F89 /* Screenshots-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C8A1E70D0103B81B8F27C330F556E477 /* Screenshots-dummy.m */; };
+		9124B9E5F891A7C05FCFCCDF8DA669ED /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1430F003D39D9906881A6AC724B7931 /* Cocoa.framework */; };
+		9C09AEDB67A20B00179B06A7BD0D3EE0 /* Screenshots-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B83D4413AAF787CD42CEF6FBBD7B8A49 /* Screenshots-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A799BEB8E075C0AF572F6D0246A292C7 /* Pods-Screenshots_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E3D4AADA9AB4DD69EF9D5351B59A015 /* Pods-Screenshots_Tests-dummy.m */; };
-		AEACCD908BCA51B164E96C61F82654D9 /* Screenshots-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 48D45CA0B5603FE8752342BCF4C02D78 /* Screenshots-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A999A6B9D825574D1DD209CDDF58DB0D /* Screenshots-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A9DA499CF766F9EFC9E8F06774E90AD /* Screenshots-dummy.m */; };
+		ABB4BE970FA81DE584445246E723BAE4 /* ScreenshotError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DD770773A092BBAEEBB45D2D71AE13 /* ScreenshotError.swift */; };
 		AFD6C01B25BBE3A3809ABD9A4AEA3BDA /* Pods-Screenshots_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 24BC379573121137E4F89DC5C14908D6 /* Pods-Screenshots_Example-dummy.m */; };
-		B8BCBD5BD11C3BF201F2A29960130345 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E7086D4E11A9A59AA1F4323C645650 /* StringExtension.swift */; };
-		C85AE9806EE21B3F1C7D92AF288A9EEF /* ScreenshotError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946F3E8035C5F6BFC31A57DC82DE1A14 /* ScreenshotError.swift */; };
-		D5FB2069A30CD77BF077E017B012A7B4 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1430F003D39D9906881A6AC724B7931 /* Cocoa.framework */; };
+		CC37591367F59526ACFBC1C49302F2C2 /* ScreenshotParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665640CCBA9A1B2C62DAD02D452EB4AA /* ScreenshotParams.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		152CCF1FA33E7B65547ADB3D32705A19 /* PBXContainerItemProxy */ = {
+		035D9AF1BF851FD84398F68FDA422654 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 3A0F1EB49405F0F1A7BFB326DC0F844D;
 			remoteInfo = Screenshots;
 		};
-		F4FB6C934F037D96DB80A48DA77F0BA3 /* PBXContainerItemProxy */ = {
+		F0967CBDA4460DB8D6BFE0501DEC3A66 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
@@ -44,55 +45,56 @@
 		053156983C493DA760B79BBF315BFD21 /* Pods_Screenshots_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Screenshots_Tests.framework; path = "Pods-Screenshots_Tests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A3FEFCA7C98EECC85FB4254CD86EA3F /* Pods-Screenshots_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Screenshots_Tests-umbrella.h"; sourceTree = "<group>"; };
 		0A46D84615ED099186C547C7C026B644 /* Pods-Screenshots_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Screenshots_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		1487CBAA2B0BE59F8162ABF7FD967BF0 /* Screenshots.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Screenshots.modulemap; sourceTree = "<group>"; };
-		15BA1E74CA61E3443FD8BFFFB0F87584 /* Screenshots.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Screenshots.release.xcconfig; sourceTree = "<group>"; };
-		1EC45D645B26FE95E60A648A9B404F86 /* Screenshots-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Screenshots-prefix.pch"; sourceTree = "<group>"; };
+		1E0744C415ADAE426DC67C57FF25A934 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		1EB405C3718E68F723F2E3CC29ADDB94 /* StringExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringExtension.swift; path = Screenshots/Classes/StringExtension.swift; sourceTree = "<group>"; };
 		24BC379573121137E4F89DC5C14908D6 /* Pods-Screenshots_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Screenshots_Example-dummy.m"; sourceTree = "<group>"; };
-		2EFB082F911EF64DDBCFF9790ED03819 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
-		3CC6FD4CBEFBE3FB09422D43E67A6C4B /* Screenshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Screenshot.swift; path = Screenshots/Classes/Screenshot.swift; sourceTree = "<group>"; };
-		48D45CA0B5603FE8752342BCF4C02D78 /* Screenshots-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Screenshots-umbrella.h"; sourceTree = "<group>"; };
+		2D88C2DB38E8C4BE42428C9D684E01E5 /* Screenshots.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Screenshots.debug.xcconfig; sourceTree = "<group>"; };
 		48FB644626909DDDCC86AF48C3C6A3EF /* Pods_Screenshots_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Screenshots_Example.framework; path = "Pods-Screenshots_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4970AD87385E4FEEE4766CECC9E1FB64 /* Pods-Screenshots_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Screenshots_Tests.modulemap"; sourceTree = "<group>"; };
+		4BF8476014A2668B806FEABD6466544D /* Screenshots.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Screenshots.modulemap; sourceTree = "<group>"; };
 		4E3D4AADA9AB4DD69EF9D5351B59A015 /* Pods-Screenshots_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Screenshots_Tests-dummy.m"; sourceTree = "<group>"; };
-		4EA7B5E73F3168304473F37B243D3EA3 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		4E480D119F53E9FA0A3952A8B956037B /* ScreenshotCLI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScreenshotCLI.swift; path = Screenshots/Classes/ScreenshotCLI.swift; sourceTree = "<group>"; };
+		4FCA8C4EAE9B1438F6BFC6853B053BC5 /* Screenshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Screenshot.swift; path = Screenshots/Classes/Screenshot.swift; sourceTree = "<group>"; };
+		5160B30DCDD12EB929886EA51B890696 /* Screenshots.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = Screenshots.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		52788F68ED35F81E9E018FB42FED1BA4 /* Pods-Screenshots_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Screenshots_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		59DD770773A092BBAEEBB45D2D71AE13 /* ScreenshotError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScreenshotError.swift; path = Screenshots/Classes/ScreenshotError.swift; sourceTree = "<group>"; };
+		5A9DA499CF766F9EFC9E8F06774E90AD /* Screenshots-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Screenshots-dummy.m"; sourceTree = "<group>"; };
 		5C3A42197A4F2208AE8648154D999240 /* Pods-Screenshots_Tests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Screenshots_Tests-Info.plist"; sourceTree = "<group>"; };
-		5FB80A31EBD778F2EEAF976341F2EB99 /* Screenshots.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Screenshots.debug.xcconfig; sourceTree = "<group>"; };
-		68E583F9B4917199DA3AEBEDFEEAB189 /* Screenshots.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = Screenshots.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		665640CCBA9A1B2C62DAD02D452EB4AA /* ScreenshotParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScreenshotParams.swift; path = Screenshots/Classes/ScreenshotParams.swift; sourceTree = "<group>"; };
 		76D2C14889B78C8BEBF4DAB634214A3D /* Screenshots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Screenshots.framework; path = Screenshots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D2255DCB9D4EC72BAEAD82ED8ED5719 /* Pods-Screenshots_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Screenshots_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		8165A17D7DD93A58A3128468F56E4EB9 /* Pods-Screenshots_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Screenshots_Example-Info.plist"; sourceTree = "<group>"; };
-		81BD51183A363E3D9DE69D7625CE798A /* Screenshots-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Screenshots-Info.plist"; sourceTree = "<group>"; };
 		9220CC99FE7D7EFD71613C6CAA1E9B36 /* Pods-Screenshots_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Screenshots_Example-acknowledgements.plist"; sourceTree = "<group>"; };
 		9285CD92B274B54AC54099300823BF06 /* Pods-Screenshots_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Screenshots_Example.modulemap"; sourceTree = "<group>"; };
-		946F3E8035C5F6BFC31A57DC82DE1A14 /* ScreenshotError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScreenshotError.swift; path = Screenshots/Classes/ScreenshotError.swift; sourceTree = "<group>"; };
+		93EA7A8463ED00AB7DF536429313A0A1 /* Screenshots.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Screenshots.release.xcconfig; sourceTree = "<group>"; };
+		9CFA50B39B79FA7682DDF2887D35EEB5 /* Screenshots-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Screenshots-prefix.pch"; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		A180AA9828AE797B91A649108C013E35 /* ScreenshotCLI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScreenshotCLI.swift; path = Screenshots/Classes/ScreenshotCLI.swift; sourceTree = "<group>"; };
+		B133C70B550BD6E4B2CA36A8D9600781 /* Screenshots-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Screenshots-Info.plist"; sourceTree = "<group>"; };
 		B5509A2F094BFF8EEEDC5329CAB6AC92 /* Pods-Screenshots_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Screenshots_Example-frameworks.sh"; sourceTree = "<group>"; };
+		B83D4413AAF787CD42CEF6FBBD7B8A49 /* Screenshots-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Screenshots-umbrella.h"; sourceTree = "<group>"; };
 		BF3452684FFAB3642CB7A8A9CB11EB0F /* Pods-Screenshots_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Screenshots_Example-umbrella.h"; sourceTree = "<group>"; };
 		C084092844BFB5227670D994DBA90A39 /* Pods-Screenshots_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Screenshots_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
 		C1430F003D39D9906881A6AC724B7931 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
-		C8A1E70D0103B81B8F27C330F556E477 /* Screenshots-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Screenshots-dummy.m"; sourceTree = "<group>"; };
+		D524B9FF7D732F785AA837181D916BE5 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
 		ECBE456E40EB84AC96EF3FDA61309E21 /* Pods-Screenshots_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Screenshots_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		EE9EABBF1A809B3F7A8A83408480875F /* Pods-Screenshots_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Screenshots_Tests-frameworks.sh"; sourceTree = "<group>"; };
-		F5E7086D4E11A9A59AA1F4323C645650 /* StringExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringExtension.swift; path = Screenshots/Classes/StringExtension.swift; sourceTree = "<group>"; };
 		F6157E1A2BA7C80B8BF9847726B0C1EB /* Pods-Screenshots_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Screenshots_Example.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1B17AB035C92B3BB72FBA863BEF4237B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9124B9E5F891A7C05FCFCCDF8DA669ED /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9F39FF920A831AD27AC7BD7AD176A307 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				7AA9E18C2D6D50639060DF43138C6F27 /* Cocoa.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		A78CC04E78DC8A6052A77CF096D9CE03 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D5FB2069A30CD77BF077E017B012A7B4 /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -107,20 +109,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1FF9E7111EA51A690B2B451F2747FC8D /* Screenshots */ = {
-			isa = PBXGroup;
-			children = (
-				3CC6FD4CBEFBE3FB09422D43E67A6C4B /* Screenshot.swift */,
-				A180AA9828AE797B91A649108C013E35 /* ScreenshotCLI.swift */,
-				946F3E8035C5F6BFC31A57DC82DE1A14 /* ScreenshotError.swift */,
-				F5E7086D4E11A9A59AA1F4323C645650 /* StringExtension.swift */,
-				283AC70862E0565741E31728B6B92564 /* Pod */,
-				F2E196A72912E71C84C151B66206EFC7 /* Support Files */,
-			);
-			name = Screenshots;
-			path = ../..;
-			sourceTree = "<group>";
-		};
 		26ED10563B37E703C49AF390428B33DB /* Pods-Screenshots_Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -138,14 +126,27 @@
 			path = "Target Support Files/Pods-Screenshots_Tests";
 			sourceTree = "<group>";
 		};
-		283AC70862E0565741E31728B6B92564 /* Pod */ = {
+		36AE76541871EB381E96C5778AF8DDB5 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				4EA7B5E73F3168304473F37B243D3EA3 /* LICENSE */,
-				2EFB082F911EF64DDBCFF9790ED03819 /* README.md */,
-				68E583F9B4917199DA3AEBEDFEEAB189 /* Screenshots.podspec */,
+				7E800905B8089C9DAD60EA4AAD914324 /* Screenshots */,
 			);
-			name = Pod;
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		7E800905B8089C9DAD60EA4AAD914324 /* Screenshots */ = {
+			isa = PBXGroup;
+			children = (
+				4FCA8C4EAE9B1438F6BFC6853B053BC5 /* Screenshot.swift */,
+				4E480D119F53E9FA0A3952A8B956037B /* ScreenshotCLI.swift */,
+				59DD770773A092BBAEEBB45D2D71AE13 /* ScreenshotError.swift */,
+				665640CCBA9A1B2C62DAD02D452EB4AA /* ScreenshotParams.swift */,
+				1EB405C3718E68F723F2E3CC29ADDB94 /* StringExtension.swift */,
+				EB488BF3E80DAFF80B33417487DCE40C /* Pod */,
+				EAB134CBEDAFFA0D531D2C373863F83E /* Support Files */,
+			);
+			name = Screenshots;
+			path = ../..;
 			sourceTree = "<group>";
 		};
 		91DF49DC8811740F966BF14E81EB0C97 /* Targets Support Files */ = {
@@ -171,7 +172,7 @@
 			isa = PBXGroup;
 			children = (
 				9D940727FF8FB9C785EB98E56350EF41 /* Podfile */,
-				F481531F1DDE70C1C1EEF738E489EC3C /* Development Pods */,
+				36AE76541871EB381E96C5778AF8DDB5 /* Development Pods */,
 				E0A1E60606E0BF6E2E10F1F01350DFE8 /* Frameworks */,
 				997F9D2EAB77DB0DD918F396CF6452C6 /* Products */,
 				91DF49DC8811740F966BF14E81EB0C97 /* Targets Support Files */,
@@ -211,32 +212,42 @@
 			name = "OS X";
 			sourceTree = "<group>";
 		};
-		F2E196A72912E71C84C151B66206EFC7 /* Support Files */ = {
+		EAB134CBEDAFFA0D531D2C373863F83E /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				1487CBAA2B0BE59F8162ABF7FD967BF0 /* Screenshots.modulemap */,
-				C8A1E70D0103B81B8F27C330F556E477 /* Screenshots-dummy.m */,
-				81BD51183A363E3D9DE69D7625CE798A /* Screenshots-Info.plist */,
-				1EC45D645B26FE95E60A648A9B404F86 /* Screenshots-prefix.pch */,
-				48D45CA0B5603FE8752342BCF4C02D78 /* Screenshots-umbrella.h */,
-				5FB80A31EBD778F2EEAF976341F2EB99 /* Screenshots.debug.xcconfig */,
-				15BA1E74CA61E3443FD8BFFFB0F87584 /* Screenshots.release.xcconfig */,
+				4BF8476014A2668B806FEABD6466544D /* Screenshots.modulemap */,
+				5A9DA499CF766F9EFC9E8F06774E90AD /* Screenshots-dummy.m */,
+				B133C70B550BD6E4B2CA36A8D9600781 /* Screenshots-Info.plist */,
+				9CFA50B39B79FA7682DDF2887D35EEB5 /* Screenshots-prefix.pch */,
+				B83D4413AAF787CD42CEF6FBBD7B8A49 /* Screenshots-umbrella.h */,
+				2D88C2DB38E8C4BE42428C9D684E01E5 /* Screenshots.debug.xcconfig */,
+				93EA7A8463ED00AB7DF536429313A0A1 /* Screenshots.release.xcconfig */,
 			);
 			name = "Support Files";
 			path = "Example/Pods/Target Support Files/Screenshots";
 			sourceTree = "<group>";
 		};
-		F481531F1DDE70C1C1EEF738E489EC3C /* Development Pods */ = {
+		EB488BF3E80DAFF80B33417487DCE40C /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				1FF9E7111EA51A690B2B451F2747FC8D /* Screenshots */,
+				1E0744C415ADAE426DC67C57FF25A934 /* LICENSE */,
+				D524B9FF7D732F785AA837181D916BE5 /* README.md */,
+				5160B30DCDD12EB929886EA51B890696 /* Screenshots.podspec */,
 			);
-			name = "Development Pods";
+			name = Pod;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		09650EBCF1CA9347F044C01ECEC5EC92 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C09AEDB67A20B00179B06A7BD0D3EE0 /* Screenshots-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		25E1427778CDA06000D91AFDB650E3CC /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -250,14 +261,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				286A8ABDD90A97D0A911FBB7903914CD /* Pods-Screenshots_Tests-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		76BB495D9D11A6C69E147FFE69DDE6D3 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				AEACCD908BCA51B164E96C61F82654D9 /* Screenshots-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -276,7 +279,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				F9DCDD6E8B16CD7C3D3108239FDE6972 /* PBXTargetDependency */,
+				7892962D0F055985AA2874409766ABA4 /* PBXTargetDependency */,
 			);
 			name = "Pods-Screenshots_Example";
 			productName = "Pods-Screenshots_Example";
@@ -285,12 +288,12 @@
 		};
 		3A0F1EB49405F0F1A7BFB326DC0F844D /* Screenshots */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F10595CD29C756A0998DB65172E8241C /* Build configuration list for PBXNativeTarget "Screenshots" */;
+			buildConfigurationList = BE16D3C6014B24DA82352698D6BAED92 /* Build configuration list for PBXNativeTarget "Screenshots" */;
 			buildPhases = (
-				76BB495D9D11A6C69E147FFE69DDE6D3 /* Headers */,
-				EAB46592A848BA303EDDFB611E70D995 /* Sources */,
-				A78CC04E78DC8A6052A77CF096D9CE03 /* Frameworks */,
-				1813E8773516E765A0F95F07873B25D7 /* Resources */,
+				09650EBCF1CA9347F044C01ECEC5EC92 /* Headers */,
+				49E4CB7968D9B175CF8BF41D8DD4E131 /* Sources */,
+				1B17AB035C92B3BB72FBA863BEF4237B /* Frameworks */,
+				97DCA26F25711FB7EA7AA7A396092B14 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -313,7 +316,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				438BB21B3946BE3C9F791EB2AB796FFD /* PBXTargetDependency */,
+				50F0E51055563B395537D212BF358DDA /* PBXTargetDependency */,
 			);
 			name = "Pods-Screenshots_Tests";
 			productName = "Pods-Screenshots_Tests";
@@ -350,13 +353,6 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		1813E8773516E765A0F95F07873B25D7 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		233BB0E654E009318BBA412F994EF3C0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -365,6 +361,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		5FB0280E9741D047BE367E5211D26698 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		97DCA26F25711FB7EA7AA7A396092B14 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -382,6 +385,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		49E4CB7968D9B175CF8BF41D8DD4E131 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				15060517AB5F962725C9FF4BFC75136D /* Screenshot.swift in Sources */,
+				56C8C841CA3365075E7A38A3BA842A59 /* ScreenshotCLI.swift in Sources */,
+				ABB4BE970FA81DE584445246E723BAE4 /* ScreenshotError.swift in Sources */,
+				CC37591367F59526ACFBC1C49302F2C2 /* ScreenshotParams.swift in Sources */,
+				A999A6B9D825574D1DD209CDDF58DB0D /* Screenshots-dummy.m in Sources */,
+				6F7C812FBE20F8DCE4A682C6F7C217F8 /* StringExtension.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9A51EC31CD1EC7E974D30F2E41A7FA72 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -390,32 +406,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EAB46592A848BA303EDDFB611E70D995 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6D0F162DC3B8519A6DCBA13E9E512587 /* Screenshot.swift in Sources */,
-				7B8116297ED33AA14C831B1460431BA4 /* ScreenshotCLI.swift in Sources */,
-				C85AE9806EE21B3F1C7D92AF288A9EEF /* ScreenshotError.swift in Sources */,
-				7F9295BA12BD92A07A1EAFFD3C4A6F89 /* Screenshots-dummy.m in Sources */,
-				B8BCBD5BD11C3BF201F2A29960130345 /* StringExtension.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		438BB21B3946BE3C9F791EB2AB796FFD /* PBXTargetDependency */ = {
+		50F0E51055563B395537D212BF358DDA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Screenshots;
 			target = 3A0F1EB49405F0F1A7BFB326DC0F844D /* Screenshots */;
-			targetProxy = F4FB6C934F037D96DB80A48DA77F0BA3 /* PBXContainerItemProxy */;
+			targetProxy = 035D9AF1BF851FD84398F68FDA422654 /* PBXContainerItemProxy */;
 		};
-		F9DCDD6E8B16CD7C3D3108239FDE6972 /* PBXTargetDependency */ = {
+		7892962D0F055985AA2874409766ABA4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Screenshots;
 			target = 3A0F1EB49405F0F1A7BFB326DC0F844D /* Screenshots */;
-			targetProxy = 152CCF1FA33E7B65547ADB3D32705A19 /* PBXContainerItemProxy */;
+			targetProxy = F0967CBDA4460DB8D6BFE0501DEC3A66 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -483,70 +487,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		21BA9BBF5E9E92DDB8C862C1545538C0 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5FB80A31EBD778F2EEAF976341F2EB99 /* Screenshots.debug.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Screenshots/Screenshots-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Screenshots/Screenshots-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MODULEMAP_FILE = "Target Support Files/Screenshots/Screenshots.modulemap";
-				PRODUCT_MODULE_NAME = Screenshots;
-				PRODUCT_NAME = Screenshots;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		232F440C8C2B0DBE6104B4FCDA8E7611 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 15BA1E74CA61E3443FD8BFFFB0F87584 /* Screenshots.release.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Screenshots/Screenshots-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Screenshots/Screenshots-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MODULEMAP_FILE = "Target Support Files/Screenshots/Screenshots.modulemap";
-				PRODUCT_MODULE_NAME = Screenshots;
-				PRODUCT_NAME = Screenshots;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -652,6 +592,38 @@
 			};
 			name = Debug;
 		};
+		8FE1C2162BE24C4A4C753D9B68162443 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2D88C2DB38E8C4BE42428C9D684E01E5 /* Screenshots.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Screenshots/Screenshots-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Screenshots/Screenshots-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MODULEMAP_FILE = "Target Support Files/Screenshots/Screenshots.modulemap";
+				PRODUCT_MODULE_NAME = Screenshots;
+				PRODUCT_NAME = Screenshots;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		C0AB89DB0533D8E2B9201FA6579824B7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -748,6 +720,38 @@
 			};
 			name = Debug;
 		};
+		EBB85A8A301AAE54ACF972299197F238 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 93EA7A8463ED00AB7DF536429313A0A1 /* Screenshots.release.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Screenshots/Screenshots-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Screenshots/Screenshots-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MODULEMAP_FILE = "Target Support Files/Screenshots/Screenshots.modulemap";
+				PRODUCT_MODULE_NAME = Screenshots;
+				PRODUCT_NAME = Screenshots;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -756,6 +760,15 @@
 			buildConfigurations = (
 				7599BD86FD28576C20F8B9B6B5ACBEC9 /* Debug */,
 				C0AB89DB0533D8E2B9201FA6579824B7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BE16D3C6014B24DA82352698D6BAED92 /* Build configuration list for PBXNativeTarget "Screenshots" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8FE1C2162BE24C4A4C753D9B68162443 /* Debug */,
+				EBB85A8A301AAE54ACF972299197F238 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -774,15 +787,6 @@
 			buildConfigurations = (
 				E369DF8E31BF42E0874721C6A024FFAA /* Debug */,
 				0C53A52741608C0BF78981F23643377A /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		F10595CD29C756A0998DB65172E8241C /* Build configuration list for PBXNativeTarget "Screenshots" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				21BA9BBF5E9E92DDB8C862C1545538C0 /* Debug */,
-				232F440C8C2B0DBE6104B4FCDA8E7611 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Target Support Files/Screenshots/Screenshots-Info.plist
+++ b/Example/Pods/Target Support Files/Screenshots/Screenshots-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.3.3</string>
+  <string>0.4.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Screenshots/Base.lproj/Main.storyboard
+++ b/Example/Screenshots/Base.lproj/Main.storyboard
@@ -762,6 +762,67 @@
                                     <action selector="windowShadowEnabledPressed:" target="XfG-lQ-9wD" id="Z4Z-ZV-6a4"/>
                                 </connections>
                             </button>
+                            <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Sf-sL-K7T">
+                                <rect key="frame" x="36" y="211" width="408" height="21"/>
+                                <subviews>
+                                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lcX-pe-kmK">
+                                        <rect key="frame" x="0.0" y="0.0" width="96" height="21"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="96" id="djo-e9-GGK"/>
+                                        </constraints>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="X" drawsBackground="YES" id="Hz7-I9-8IZ">
+                                            <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="6Fv-jF-3CQ"/>
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LQ4-3v-hBD">
+                                        <rect key="frame" x="104" y="0.0" width="96" height="21"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Y" drawsBackground="YES" id="yLx-XD-MUU">
+                                            <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="10i-3i-yar"/>
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wJp-ie-QNh">
+                                        <rect key="frame" x="208" y="0.0" width="96" height="21"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Width" drawsBackground="YES" id="Bca-wu-ZYW">
+                                            <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="2sh-sh-Wjr"/>
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="96h-fG-XLQ">
+                                        <rect key="frame" x="312" y="0.0" width="96" height="21"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Height" drawsBackground="YES" id="o9i-A4-udx">
+                                            <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="gGy-pi-AnN"/>
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="96h-fG-XLQ" firstAttribute="width" secondItem="lcX-pe-kmK" secondAttribute="width" id="7f7-tT-gtU"/>
+                                    <constraint firstItem="lcX-pe-kmK" firstAttribute="width" secondItem="LQ4-3v-hBD" secondAttribute="width" id="8gA-KR-5kH"/>
+                                    <constraint firstItem="wJp-ie-QNh" firstAttribute="width" secondItem="lcX-pe-kmK" secondAttribute="width" id="yXQ-OD-dhi"/>
+                                </constraints>
+                                <visibilityPriorities>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                </visibilityPriorities>
+                                <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                </customSpacing>
+                            </stackView>
                         </subviews>
                         <constraints>
                             <constraint firstItem="bHh-9L-2hp" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="14" id="1BH-iQ-aD9"/>
@@ -774,17 +835,23 @@
                             <constraint firstItem="toi-UU-OIU" firstAttribute="top" secondItem="EA5-nh-fbT" secondAttribute="bottom" constant="12" id="Iur-jG-quS"/>
                             <constraint firstItem="EA5-nh-fbT" firstAttribute="trailing" secondItem="toi-UU-OIU" secondAttribute="trailing" id="O3t-w9-ZZr"/>
                             <constraint firstItem="Srk-J0-g5K" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" id="Tib-5S-q6G"/>
+                            <constraint firstItem="0Sf-sL-K7T" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" constant="38" id="Y1g-R5-SPg"/>
                             <constraint firstItem="toi-UU-OIU" firstAttribute="centerY" secondItem="FoD-a0-Pkp" secondAttribute="centerY" id="bQE-nM-99w"/>
+                            <constraint firstItem="0Sf-sL-K7T" firstAttribute="centerX" secondItem="m2S-Jp-Qdl" secondAttribute="centerX" id="daO-S4-YLt"/>
                             <constraint firstItem="FoD-a0-Pkp" firstAttribute="centerX" secondItem="m2S-Jp-Qdl" secondAttribute="centerX" id="eJg-MV-M8P"/>
                             <constraint firstAttribute="bottom" secondItem="FoD-a0-Pkp" secondAttribute="bottom" constant="10" id="l1o-Pz-Ffh"/>
                             <constraint firstItem="Srk-J0-g5K" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" id="xAy-gZ-0VZ"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="heightTextField" destination="96h-fG-XLQ" id="LDb-cS-3J5"/>
                         <outlet property="imageView" destination="Srk-J0-g5K" id="eGU-up-z5M"/>
                         <outlet property="soundEnabledField" destination="toi-UU-OIU" id="Tmd-Gd-NlX"/>
                         <outlet property="textField" destination="ZfK-AB-imd" id="Xhr-aA-A4a"/>
+                        <outlet property="widthTextField" destination="wJp-ie-QNh" id="CSS-6B-LZY"/>
                         <outlet property="windowShadowEnabledField" destination="EA5-nh-fbT" id="JvG-SE-IH0"/>
+                        <outlet property="xTextField" destination="lcX-pe-kmK" id="mfz-WE-UQy"/>
+                        <outlet property="yTextField" destination="LQ4-3v-hBD" id="yNV-6u-fo5"/>
                     </connections>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/Example/Screenshots/ViewController.swift
+++ b/Example/Screenshots/ViewController.swift
@@ -16,6 +16,11 @@ class ViewController: NSViewController {
   @IBOutlet weak var soundEnabledField: NSButton!
   @IBOutlet weak var windowShadowEnabledField: NSButton!
   
+  @IBOutlet weak var xTextField: NSTextField!
+  @IBOutlet weak var yTextField: NSTextField!
+  @IBOutlet weak var widthTextField: NSTextField!
+  @IBOutlet weak var heightTextField: NSTextField!
+  
   lazy var cliScreenshots = ScreenshotCLI()
   
   override func viewDidLoad() {
@@ -29,9 +34,33 @@ class ViewController: NSViewController {
     // Update the view, if already loaded.
     }
   }
-
+  
+  // MARK: - Actions
+  
   @IBAction func didTapCreateScreenshot(sender: Any) {
-    cliScreenshots.createScreenshot { [weak self] (result) in
+    let screenshotRect: CGRect?
+    
+    if let x = Int(xTextField.stringValue),
+       let y = Int(yTextField.stringValue),
+       let width = Int(widthTextField.stringValue),
+       let height = Int(heightTextField.stringValue){
+      screenshotRect = CGRect(x: x,
+                              y: y,
+                              width: width,
+                              height: height)
+    } else {
+      screenshotRect = nil
+    }
+    
+    let params: ScreenshotParams?
+    
+    if let screenshotRect = screenshotRect {
+      params = ScreenshotParams(selectionRect: screenshotRect)
+    } else {
+      params = nil
+    }
+    
+    cliScreenshots.createScreenshot(params: params) { [weak self ](result) in
       guard let self = self else { return }
       switch result {
       case .success(let screenshot):

--- a/Example/Screenshots/ViewController.swift
+++ b/Example/Screenshots/ViewController.swift
@@ -43,7 +43,7 @@ class ViewController: NSViewController {
     if let x = Int(xTextField.stringValue),
        let y = Int(yTextField.stringValue),
        let width = Int(widthTextField.stringValue),
-       let height = Int(heightTextField.stringValue){
+       let height = Int(heightTextField.stringValue) {
       screenshotRect = CGRect(x: x,
                               y: y,
                               width: width,

--- a/Screenshots/Classes/ScreenshotCLI.swift
+++ b/Screenshots/Classes/ScreenshotCLI.swift
@@ -25,7 +25,8 @@ public class ScreenshotCLI {
       .appendingPathExtension("png")
   }
   
-  public func createScreenshot(completion: @escaping (Result<Screenshot, Error>) -> Void) {
+  public func createScreenshot(params: ScreenshotParams? = nil,
+                               completion: @escaping (Result<Screenshot, Error>) -> Void) {
     guard let url = createScreenshotURL() else {
       completion(.failure(ScreenshotError.screenshotDirectoryIsInvalid))
       return
@@ -41,11 +42,23 @@ public class ScreenshotCLI {
       task.standardOutput = pipe
       
       task.launchPath = "/usr/sbin/screencapture"
-      
-      var args: String = "-s"
+    
+      var args = "-"
       
       if !soundEnabled {
-        args.append("x")
+        if !soundEnabled {
+          args.append("x")
+        }
+      }
+    
+      if let rect = params?.selectionRect {
+        args.append(String(format: "R%d,%d,%d,%d",
+                           Int(rect.origin.x),
+                           Int(rect.origin.y),
+                               Int(rect.size.width),
+                                   Int(rect.size.height)))
+      } else {
+        args.append("s")
       }
       
       task.arguments = [args, url.path]

--- a/Screenshots/Classes/ScreenshotCLI.swift
+++ b/Screenshots/Classes/ScreenshotCLI.swift
@@ -55,8 +55,8 @@ public class ScreenshotCLI {
         args.append(String(format: "R%d,%d,%d,%d",
                            Int(rect.origin.x),
                            Int(rect.origin.y),
-                               Int(rect.size.width),
-                                   Int(rect.size.height)))
+                           Int(rect.size.width),
+                           Int(rect.size.height)))
       } else {
         args.append("s")
       }

--- a/Screenshots/Classes/ScreenshotParams.swift
+++ b/Screenshots/Classes/ScreenshotParams.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct ScreenshotParams {
+  let selectionRect: CGRect?
+  
+  public init(selectionRect: CGRect?) {
+    self.selectionRect = selectionRect
+  }
+}


### PR DESCRIPTION
@memstel this PR adds a possibility to capture some rectangle on the screen with the Screenshots framework.
We need this feature for "Capture previous selection area" feature of Zappy app" (https://github.com/blackbeltlabs/zappy/pull/213)

You can test the rectangle selection through the Example project where I also added changes:

![image](https://user-images.githubusercontent.com/15073398/110818606-18571e80-8296-11eb-8e40-23dfcd42d807.png)
