### PR TITLE
Fix ScreenshotRectHandler issue when nil rectangle was returned if start or end point was zero (not both of them as it should be)

### DIFF
--- a/Sources/Screenshots/ScreenshotRectHandler.swift
+++ b/Sources/Screenshots/ScreenshotRectHandler.swift
@@ -42,7 +42,7 @@ final class ScreenshotRectHandler {
 
 private extension ScreenshotRectHandler {
   func rectangleFromTwoPoints(start: CGPoint, end: CGPoint) -> CGRect? {
-      guard start != .zero && end != .zero else {
+      if start == .zero && end == .zero {
           return nil
       }
       


### PR DESCRIPTION
https://blackbeltlabs.slack.com/archives/C9E5M03CL/p1705075358406889 - this PR fixes an issue that was reported by a user Tomasz Pechota